### PR TITLE
add default case for switch statements

### DIFF
--- a/marble-plotter-simple/src/main/java/org/marble/plotter/simple/service/PlotterServiceImpl.java
+++ b/marble-plotter-simple/src/main/java/org/marble/plotter/simple/service/PlotterServiceImpl.java
@@ -171,6 +171,10 @@ public class PlotterServiceImpl implements PlotterService {
         }
             break;
         }
+        //missing default case
+        default:
+            // add default case
+            break;
 
         chart.setData(singleData);
         chart.setOptions(getOptions(topic, plotType));
@@ -293,6 +297,11 @@ public class PlotterServiceImpl implements PlotterService {
             col.put("type", "number");
             cols.add(col);
         }
+        //missing default case
+        default:
+            // add default case
+            break;
+
         }
         return cols;
     }
@@ -716,6 +725,11 @@ public class PlotterServiceImpl implements PlotterService {
         }
             break;
         }
+        //missing default case
+        default:
+            // add default case
+            break;
+
         return col;
 
     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html
